### PR TITLE
fix: fix ignore patterns

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -18,8 +18,12 @@ module.exports = {
     // Snapshots
     setupFilesAfterEnv: ['./node_modules/jest-enzyme/lib/index.js'],
     // Coverage
+    collectCoverage: true,
     collectCoverageFrom: [
-        'src/**/*.js',
+        'www/**/*.js',
+    ],
+    coveragePathIgnorePatterns: [
+        '.*\\.data\\.js',
     ],
     coverageThreshold: {
         global: {
@@ -29,10 +33,4 @@ module.exports = {
             statements: -10,
         },
     },
-    testPathIgnorePatterns: [
-        '*.data.js',
-    ],
-    coveragePathIgnorePatterns: [
-        '*.data.js',
-    ],
 };

--- a/www/pages/home/Home.test.js
+++ b/www/pages/home/Home.test.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import Home from './Home';
+
+it('should render correctly', () => {
+    const tree = shallow(<Home />);
+
+    expect(tree).toMatchSnapshot();
+});

--- a/www/pages/home/__snapshots__/Home.test.js.snap
+++ b/www/pages/home/__snapshots__/Home.test.js.snap
@@ -1,0 +1,10 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`should render correctly 1`] = `
+<div
+  className="home"
+>
+  Home Page
+  <Contacts />
+</div>
+`;


### PR DESCRIPTION
Fixes ignore patterns, which, [as per the documentation](https://jestjs.io/docs/en/configuration.html#testpathignorepatterns-array-string), expect regex patterns.

Also ignores `no-useless-escape` rule because it doesn't behave with escaping characters in stringified regex patterns.