### PR TITLE
fix: fixes jest-config composition

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,3 +1,3 @@
 const { compose, baseConfig, withWeb } = require('@moxy/jest-config');
 
-module.exports = compose({ baseConfig, withWeb });
+module.exports = compose([baseConfig, withWeb]);


### PR DESCRIPTION
This PR fixes the composition of addons with the `jest-config` plugin.

Items are passed in array, not in object.