### PR TITLE
fix: use of react hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1848,9 +1848,9 @@
       }
     },
     "@moxy/next-compile-node-modules": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@moxy/next-compile-node-modules/-/next-compile-node-modules-1.1.0.tgz",
-      "integrity": "sha512-zEvIK86oNTxwnGyZOeGO2ieyCTlvxtlQ8JNnRuqzJIKbkm5XUrifbO+jsWkzaOVBcfU8Uyb6Emg6MtFRCIsySA=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@moxy/next-compile-node-modules/-/next-compile-node-modules-1.1.1.tgz",
+      "integrity": "sha512-h5h7d7CRE/QHHWDeP/NYvdeTACVS4WmNsFJzZYrBdfTJEltfGYBaHLFOUA+/nVZiKvU1ZY7NzFujKhsmLDh4Rw=="
     },
     "@moxy/next-webpack-oneof": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   },
   "dependencies": {
     "@moxy/next-common-files": "^1.2.0",
-    "@moxy/next-compile-node-modules": "^1.1.0",
+    "@moxy/next-compile-node-modules": "^1.1.1",
     "@moxy/next-webpack-oneof": "^1.0.0",
     "@zeit/next-css": "^0.2.1-canary.4",
     "cross-env": "^6.0.0",


### PR DESCRIPTION
Updated `@moxy/next-compile-node-modules` since it was causing a problem with different instances of React making stuff like React Hooks not working.

Check https://github.com/moxystudio/next-compile-node-modules/pull/4 for more information.