### PR TITLE
fix: fix typo on available scripts section

### DIFF
--- a/docusaurus/docs/what-is-included/available-scripts.md
+++ b/docusaurus/docs/what-is-included/available-scripts.md
@@ -67,4 +67,4 @@ This script lints only your Javascript files.
 
 ### `npm run lint:stylelint`
 
-This script lints only your Javascript files.
+This script lints only your CSS files.


### PR DESCRIPTION
This PR proposes a fix for a typo on the `Available Scripts` section. More precisely, the description for the `npm run lint:stylelint` was `This script lints only your JavaScript files` instead of `This script lints only your CSS files`.