### PR TITLE
docs: add link to private recipes

### DIFF
--- a/docusaurus/docs/what-is-included/browser-support.md
+++ b/docusaurus/docs/what-is-included/browser-support.md
@@ -1,7 +1,7 @@
 ---
 id: browser-support
-title: Browser Support
-sidebar_label: Browser Support
+title: Browser support
+sidebar_label: Browser support
 ---
 
 By default, this boilerplate is configured to support the latest two versions of the most popular desktop and mobile browsers.

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -32,6 +32,11 @@ module.exports = {
             label: 'Recipes',
             items: [
                 'recipes/api/recipe-api',
+                {
+                    type: 'link',
+                    label: 'Private recipes',
+                    href: 'https://next-with-moxy-recipes.moxy.tech',
+                },
             ],
         },
         {

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -31,7 +31,7 @@ module.exports = {
             type: 'category',
             label: 'Recipes',
             items: [
-                'recipes/api/recipe-api',
+                'recipes/recipe-api',
                 {
                     type: 'link',
                     label: 'Private recipes',

--- a/docusaurus/sidebars.js
+++ b/docusaurus/sidebars.js
@@ -31,7 +31,7 @@ module.exports = {
             type: 'category',
             label: 'Recipes',
             items: [
-                'recipes/recipe-api',
+                'recipes/recipe-rest-api',
                 {
                     type: 'link',
                     label: 'Private recipes',

--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -14,3 +14,9 @@ body,
 main {
     flex-grow: 1;
 }
+
+@media (max-width: 996px) {
+    .navbar .navbar__items.navbar__items--right {
+        display: none;
+    }
+}


### PR DESCRIPTION
Also:

- Lowercase "Browser Support" for consistency with other docs
- Let the header logo & title occupy the whole width when in tablet/mobile