### PR TITLE
fix: css out of order in a production build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,9 +19,6 @@
   "browserslist": [
     "extends browserslist-config-google/modern"
   ],
-  "sideEffects": [
-    "*.css"
-  ],
   "scripts": {
     "dev": "cross-env NODE_ICU_DATA=node_modules/full-icu next",
     "prebuild": "rimraf .next",


### PR DESCRIPTION
The "sideEffects" property in package.json improves webpack treeshaking. However that causes the out-of-order CSS we were seeing in production builds. We may enable again once the bug is fixed.

For more context see https://github.com/webpack/webpack/issues/7094 and https://github.com/webpack-contrib/mini-css-extract-plugin/issues/202.