### PR TITLE
chore: change dockerfile to support multi-stage builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 node_modules
 npm-debug.log*
-.git*
+.git
 /.env*
 /.next
 /coverage

--- a/.env.sample
+++ b/.env.sample
@@ -1,6 +1,6 @@
 # These env variables may be configured for the development environment
 
-# Enable or disable compressed responses (gzip & brotli)
+# Enable or disable compressed responses
 #COMPRESSION=1
 
 # Google Analytics Tracking Code

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,11 @@
-# Use latest stable version of node (12 at the moment)
-FROM node:12-alpine
+# Dockerfile that produce Lightweight runtime images
+# Inspired by https://github.com/zeit/next.js/issues/121#issuecomment-541399420
 
-# Define build args
-ARG GA_TRACKING_ID
+# -- BASE STAGE --------------------------------
 
-# Define environment variables
-ENV PORT 3000
-ENV GA_TRACKING_ID $GA_TRACKING_ID
+FROM node:12-alpine AS base
 
-# Define project dir
-WORKDIR /usr/src/app
-
-# Install OS deps necessary by some packages (e.g.: node-canvas)
+# Install OS libs necessary by some packages during `npm i` (e.g.: node-canvas)
 RUN apk add --update --no-cache \
     make \
     g++ \
@@ -20,16 +14,48 @@ RUN apk add --update --no-cache \
     giflib-dev \
     pango-dev
 
-# Install dependencies
+WORKDIR /src
+
 COPY package*.json ./
-RUN npm install
+RUN npm ci --no-audit
 
-# Copy source files
+# -- CHECK STAGE --------------------------------
+
+FROM base AS check
+
+ARG CI
+ENV CI $CI
+
 COPY . .
+RUN npm run lint
+RUN npm test
 
-# Build project
+# -- BUILD STAGE --------------------------------
+
+FROM base AS build
+
+# Define build arguments & map them to environment variables
+ARG GA_TRACKING_ID
+ENV GA_TRACKING_ID $GA_TRACKING_ID
+
+# Build the project and then dispose files not necessary to run the project
+# This will make the runtime image as small as possible
+COPY . .
+RUN npx next telemetry disable > /dev/null
 RUN npm run build
+RUN npm prune --production --no-audit
+RUN rm -rf .next/cache
 
-# Expose port and start command
+# -- RUNTIME STAGE --------------------------------
+
+FROM node:12-alpine AS runtime
+
+WORKDIR /usr/app
+
+COPY --from=build /src/package.json /usr/app/package.json
+COPY --from=build /src/node_modules /usr/app/node_modules
+COPY --from=build /src/.next /usr/app/.next
+
+ENV PORT 3000
 EXPOSE $PORT
 CMD npm start -- -p $PORT

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ MOXY's boilerplate to accelerate the setup of new [Next.js](https://nextjs.org/)
 
 Please check out the documentation page at https://next-with.moxy.tech.
 
-To view the documentation localy, you may run:
+To view the documentation locally, you may run:
 
 ```bash
 npm i --prefix docusarus

--- a/docusaurus/docs/recipes/rest-api.md
+++ b/docusaurus/docs/recipes/rest-api.md
@@ -6,7 +6,7 @@ sidebar_label: Adding a simple REST API
 
 Sometimes a project may require a simple REST API (e.g. to send an email). Next.js comes with the ability to create API endpoints, which makes this recipe very straightforward. Please read their [API routes](https://nextjs.org/docs#api-routes) documentation as they extend Node.js `req` and `res` objects with additional functionality and ship with built-in middleware.
 
-⚠️ Please note that if you require more than a simple API with one or two endpoints, it's better if you create a separate project (and repository) for it.
+> ⚠️ Please note that if you require more than a simple API with one or two endpoints, it's better if you create a separate project (and repository) for it.
 
 ## Walk-through
 

--- a/docusaurus/docs/what-is-included/docker.md
+++ b/docusaurus/docs/what-is-included/docker.md
@@ -18,16 +18,23 @@ Afterwards you'll be able to find your project running at [http://localhost:3000
 This `Dockerfile` is also how you can pass environment variables to your Docker container running this application. In the `Dockerfile`, you do this with two steps:
 
 - Define an `ARG` for the variable to be received.
-- Pass that `ARG` into an `ENV` argument that will exist inside the application's process.
+- Pass that `ARG` into an `ENV` argument that will exist during the build process as well as the server-runtime process.
 
 Example:
 
 ```bash
-# Define build arguments
+# Define build arguments & map them to environment variables
 ARG SOME_ARGUMENT
-
-# Define environment variables
 ENV SOME_ENV_VAR $SOME_ARGUMENT
 ```
 
-You can check the existing `Dockerfile` to see how we're configuring `GA_TRACKING_ID` for an example on this process.
+You can check the existing `Dockerfile` to see how we're configuring `GA_TRACKING_ID`.
+
+## Multi-stage builds
+
+The Dockerfile we provide allows for [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/), with the following benefits:
+
+- The final runtime image is much lighter because it doesn't contain dev dependencies and other intermediate artifacts produced during the build phase.
+- It allows to target a specific stage when building, which is useful to create a CI/CD pipeline. As an example, you may run the project tests by specifying `--target check` when calling `docker build`.
+
+> ℹ️ You may leverage Docker [BuildKit](https://docs.docker.com/develop/develop-images/build_enhancements/) to [skip stages](https://github.com/docker/cli/issues/1134#issuecomment-399005853) that are not needed for the specified target. To do so, set DOCKER_BUILDKIT=1 when running `docker build`.

--- a/docusaurus/docs/what-is-included/environment-variables.md
+++ b/docusaurus/docs/what-is-included/environment-variables.md
@@ -67,7 +67,7 @@ if (process.env.FEATURE_A) {
 While build-time environments are prefereable, there are some scenarios where they might pose a problem.
 One scenario is when it's impossible or unfesable to having to rebuild the project when configuration changes. If that's the case, you may use [runtime configuration](https://nextjs.org/docs#runtime-configuration) instead.
 
-⚠️ Be aware that runtime configuration will make your project incompatible with serverless deployments and static optimization.
+> ⚠️ Be aware that runtime configuration will make your project incompatible with serverless deployments and static optimization.
 
 You can access runtime configuration by using `next/config`:
 

--- a/docusaurus/docs/what-is-included/eslint-stylelint.md
+++ b/docusaurus/docs/what-is-included/eslint-stylelint.md
@@ -8,4 +8,4 @@ The boilerplate includes our own linting presets for linting both Javascript and
 
 For linting Javascript files, we use [`eslint-config-moxy`](https://github.com/moxystudio/eslint-config-moxy), and for linting CSS files we use [`stylelint-config-moxy`](https://github.com/moxystudio/stylelint-config-moxy).
 
-ℹ️ Make sure that your editor supports [**ESLint**](https://eslint.org/) and [**Stylelint**](https://stylelint.io/) for the best experience.
+> ℹ️ Make sure that your editor supports [**ESLint**](https://eslint.org/) and [**Stylelint**](https://stylelint.io/) for the best experience.

--- a/docusaurus/docs/what-is-included/webpack-file-loaders.md
+++ b/docusaurus/docs/what-is-included/webpack-file-loaders.md
@@ -15,13 +15,13 @@ Here's the list of conventions:
 
     This suffix is used when you want a file to be translated into base64 and sent with your bundle instead of being loaded with a standard URL (e.g., for assets above the fold, you might want to use this to avoid [flashing of unstyled content](https://en.wikipedia.org/wiki/Flash_of_unstyled_content)).
 
-    ⚠️ Be aware that base64 encoding increases file sizes by roughly 33%.
+    > ⚠️ Be aware that base64 encoding increases file sizes by roughly 33%.
 
 - `.inline.`
 
     This suffix is used when you want your `.svg` files to be put as inline HTML on your pages.
 
-    ℹ️ Support is limited to `.svg` files for now.
+    > ℹ️ Support is limited to `.svg` files for now.
 
 - No suffix
 


### PR DESCRIPTION
- The final runtime image is much lighter because it doesn't contain dev dependencies and other intermediate artifacts produced during the build phase.
- It allows to target a specific stage when building, which is useful to create a CI/CD pipeline. As an example, you may run the project tests by specifying `--target check` when calling `docker build`.