### PR TITLE
chore: push to current branch after a release

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "start": "cross-env NODE_ENV=production NODE_ICU_DATA=node_modules/full-icu next start",
     "test": "jest",
     "release": "standard-version",
-    "postrelease": "git push --follow-tags origin master",
+    "postrelease": "git push --follow-tags origin HEAD",
     "lint": "npm run lint:eslint && npm run lint:stylelint",
     "lint:eslint": "eslint --ignore-path .gitignore .",
     "lint:stylelint": "stylelint --ignore-path .gitignore \"**/*.css\"",


### PR DESCRIPTION
The current script posts always to the master branch, which is not always the case. As an example, you might be pushing to a release line branch containing a hotfix.