### PR TITLE
docs: update folder-structure

### DIFF
--- a/docusaurus/docs/welcome/conventions.md
+++ b/docusaurus/docs/welcome/conventions.md
@@ -11,7 +11,8 @@ This boilerplate establishes some conventions that the team executing the projec
 The folder-structure convention favours co-location of assets and their requesters. Here's how it looks like:
 
 ```
-├── server.js
+├── package.json
+├── package-lock.json
 ├── pages
 │   ├── _app.js
 │   └── index.js


### PR DESCRIPTION
Updated folder-structure in the conventions docs page by deleting `server.js` and adding the `package-lock.json` and `package.json` files.