### PR TITLE
fix: rerender with intl test

### DIFF
--- a/www/shared/tests/utils/render-with-intl/render-with-intl.test.js
+++ b/www/shared/tests/utils/render-with-intl/render-with-intl.test.js
@@ -16,7 +16,7 @@ it('should correctly rerender with passed children', () => {
         <FormattedMessage id="foo" />,
     );
 
-    rerenderWithIntl('bar');
+    rerenderWithIntl(<FormattedMessage id={ 'bar' } />);
 
     expect(getByText('bar')).toBeInTheDocument();
 });


### PR DESCRIPTION
Fixes `rerenderWithIntl` test. Missed this during code review, so here's the PR with the fix.

As it was, this test was not testing whether `rerenderWithIntl` was wrapping the `intl` provider, because no child would require it.

With a `FormattedMessage` child, this test now actually tests if `rerenderWithIntl` wraps its children with the necessary provider and does not throw any errors.