### PR TITLE
fix: serve public assets with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -55,6 +55,7 @@ WORKDIR /usr/app
 COPY --from=build /src/package.json /usr/app/package.json
 COPY --from=build /src/node_modules /usr/app/node_modules
 COPY --from=build /src/.next /usr/app/.next
+COPY --from=build /src/public /usr/app/public
 
 ENV PORT 3000
 EXPOSE $PORT


### PR DESCRIPTION
This PR fixes the bug where files in `public` folder weren't being served when deploying with Docker.