### PR TITLE
feat(ci): Fully qualified URL for SEO image

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -5,3 +5,6 @@
 
 # Google Analytics Tracking Code
 #GA_TRACKING_ID=
+
+# Fully qualified site URL, without trailing slash
+#SITE_URL=http://localhost:3000

--- a/.env.sample
+++ b/.env.sample
@@ -7,4 +7,5 @@
 #GA_TRACKING_ID=
 
 # Fully qualified site URL, without trailing slash
-#SITE_URL=http://localhost:3000
+# This variable is used in www/app/App.data.js to have absolute paths in SEO images
+SITE_URL=http://localhost:3000

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,9 @@ FROM base AS build
 
 # Define build arguments & map them to environment variables
 ARG GA_TRACKING_ID
+ARG SITE_URL
 ENV GA_TRACKING_ID $GA_TRACKING_ID
+ENV SITE_URL $SITE_URL
 
 # Build the project and then dispose files not necessary to run the project
 # This will make the runtime image as small as possible

--- a/docusaurus/docs/welcome/instructions.md
+++ b/docusaurus/docs/welcome/instructions.md
@@ -21,7 +21,7 @@ Keep in mind, part of adapting this boilerplate into a deliverable project is al
     - `Contacts.data.js`: In the `name` field. This file is a sample file and you might want to delete it altogether.
     - In this document, in case you want to use it.
 
-2. For local development, create a `.env` file and set a value for `SITE_URL` environment variable. You will likely want to use the provided example, `http://localhost:3000`
+2. Copy `.env.sample` to `.env`. Ensure `SITE_URL` has a value set, and that it points to the same URL as where your development server is running. If you are using all default values, it should just work out of the box.
 
 3. Delete the following files and folders:
 

--- a/docusaurus/docs/welcome/instructions.md
+++ b/docusaurus/docs/welcome/instructions.md
@@ -21,10 +21,7 @@ Keep in mind, part of adapting this boilerplate into a deliverable project is al
     - `Contacts.data.js`: In the `name` field. This file is a sample file and you might want to delete it altogether.
     - In this document, in case you want to use it.
 
-2. Change all instances of `{project-domain}` into the domain that will be used in production:
-
-    - `package.json`: In the `description` field.
-    - `App.data.js`: In the `url` field.
+2. For local development, create a `.env` file and set a value for `SITE_URL` environment variable. You will likely want to use the provided example, `http://localhost:3000`
 
 3. Delete the following files and folders:
 

--- a/docusaurus/docs/what-is-included/docker.md
+++ b/docusaurus/docs/what-is-included/docker.md
@@ -28,7 +28,7 @@ ARG SOME_ARGUMENT
 ENV SOME_ENV_VAR $SOME_ARGUMENT
 ```
 
-You can check the existing `Dockerfile` to see how we're configuring `GA_TRACKING_ID`.
+You can check the existing `Dockerfile` to see how we're configuring `GA_TRACKING_ID` and `SITE_URL`.
 
 ## Multi-stage builds
 

--- a/docusaurus/docs/what-is-included/environment-variables.md
+++ b/docusaurus/docs/what-is-included/environment-variables.md
@@ -13,6 +13,7 @@ The following environment variables already come with the boilerplate:
 | Identifier | Type | Description | Value |
 |----------- | ---- | ----------- |-------|
 | GA_TRACKING_ID | Build-time | Google Analytics Tracking ID that is used to track page views | `undefined` |
+| SITE_URL | Build-time | Fully qualified URL where the application will be available at (without trailing slash) | `undefined` |
 
 ## Build-time environment variables
 

--- a/next.config.js
+++ b/next.config.js
@@ -59,5 +59,6 @@ module.exports = (phase, nextConfig) =>
         compress: process.env.COMPRESSION !== '0',
         env: {
             GA_TRACKING_ID: process.env.GA_TRACKING_ID,
+            SITE_URL: process.env.SITE_URL,
         },
     })(phase, nextConfig);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "project-name",
   "version": "0.0.0",
-  "description": "The https://{project-domain} web app",
+  "description": "{project-name} web app",
   "author": "MOXY <hello@moxy.studio>",
   "private": true,
   "license": "UNLICENSED",

--- a/www/app/App.data.js
+++ b/www/app/App.data.js
@@ -1,9 +1,9 @@
 import seoImage from '../shared/media/images/seo.png';
 
 export default {
-    url: 'https://{project-domain}',
+    url: process.env.SITE_URL,
     title: '{project-name}',
     description: '{project-description}',
     keywords: ['{project-keyword-1}', '{project-keyword-2}'],
-    image: { src: seoImage, width: 1200, height: 630 },
+    image: { src: `${process.env.SITE_URL}${seoImage}`, width: 1200, height: 630 },
 };


### PR DESCRIPTION
Add SITE_URL environment variable to replace `{project-domain}` placeholder

Example application: https://frontend-mr1-4izymcemfa-ew.a.run.app/
Using the above URL in twitter and facebook card validators should show the default placeholder image and values

Twitter
---

<img width="446" alt="Screen Shot 2020-02-12 at 14 29 23" src="https://user-images.githubusercontent.com/102879/74344231-2fca8c00-4da4-11ea-9067-0fd60547c307.png">


Facebook
---

<img width="542" alt="Screen Shot 2020-02-12 at 14 29 55" src="https://user-images.githubusercontent.com/102879/74344341-538dd200-4da4-11ea-931a-19e2e99ab4b7.png">
