### PR TITLE
chore: update eslint config

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,12 +1,8 @@
 {
     "root": true,
     "extends": [
-        "@moxy/eslint-config/es9",
-        "@moxy/eslint-config/addons/babel-parser",
-        "@moxy/eslint-config/addons/browser",
-        "@moxy/eslint-config/addons/node",
-        "@moxy/eslint-config/addons/es-modules",
-        "@moxy/eslint-config/addons/jest",
-        "@moxy/eslint-config/addons/react"
+        "@moxy/eslint-config-isomorphic",
+        "@moxy/eslint-config-jest",
+        "@moxy/eslint-config-react"
     ]
 }

--- a/docusaurus/docs/what-is-included/eslint-stylelint.md
+++ b/docusaurus/docs/what-is-included/eslint-stylelint.md
@@ -6,6 +6,8 @@ sidebar_label: ESLint & Stylelint
 
 The boilerplate includes our own linting presets for linting both Javascript and CSS files.
 
-For linting Javascript files, we use [`@moxy/eslint-config`](https://github.com/moxystudio/eslint-config), and for linting CSS files we use [`@moxy/stylelint-config`](https://github.com/moxystudio/stylelint-config).
+For linting Javascript files, we use [`@moxy/eslint-config-isomorphic`](https://github.com/moxystudio/eslint-config/tree/master/packages/eslint-config-isomorphic), [`@moxy/eslint-config-jest`](https://github.com/moxystudio/eslint-config/tree/master/packages/eslint-config-jest) and [`@moxy/eslint-config-react`](https://github.com/moxystudio/eslint-config/tree/master/packages/eslint-config-react).
+
+For linting CSS files we use [`@moxy/stylelint-config`](https://github.com/moxystudio/stylelint-config).
 
 > ℹ️ Make sure that your editor supports [**ESLint**](https://eslint.org/) and [**Stylelint**](https://stylelint.io/) for the best experience.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11488,8 +11488,7 @@
           "dependencies": {
             "acorn": {
               "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-              "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+              "resolved": "",
               "dev": true
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2379,23 +2379,66 @@
         }
       }
     },
-    "@moxy/eslint-config": {
-      "version": "10.1.1",
-      "resolved": "https://registry.npmjs.org/@moxy/eslint-config/-/eslint-config-10.1.1.tgz",
-      "integrity": "sha512-nMi834gCRV67PgsIC4QDL+y+cyRThlWgMi4B7dms9TnXHoLuqJDPWg9iBq99wkbKXBBH3+8Xt/kQ4hhfat/OOA==",
+    "@moxy/eslint-config-browser": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@moxy/eslint-config-browser/-/eslint-config-browser-1.0.0.tgz",
+      "integrity": "sha512-U2xhZOEKg6WMcEJ8V9brUZOXd9gl7iWe/Q9BXr0rdgUha/g6M/4SpueuSAzgU4U2ZbtKLPXTKhNDvqCQWPrbdQ==",
       "dev": true,
       "requires": {
-        "@vue/eslint-config-prettier": "^6.0.0",
+        "@moxy/eslint-config-core": "^1.0.0",
         "babel-eslint": "^10.0.3",
         "eslint-plugin-babel": "^5.3.0",
-        "eslint-plugin-jest": "^23.0.4",
+        "eslint-plugin-prefer-import": "0.0.1"
+      }
+    },
+    "@moxy/eslint-config-core": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@moxy/eslint-config-core/-/eslint-config-core-1.0.0.tgz",
+      "integrity": "sha512-70K3F3bJ6mDTa5iADyfY0tbl8kAHf6DnKObFm9C/pO4i0lfKgTq0Uue/BFRtLRTF8HQlAABav0wFh3qrIRfxvQ==",
+      "dev": true,
+      "requires": {
         "eslint-plugin-jsdoc": "^20.3.1",
-        "eslint-plugin-prefer-import": "0.0.1",
-        "eslint-plugin-prettier": "^3.1.2",
+        "eslint-plugin-prefer-import": "0.0.1"
+      }
+    },
+    "@moxy/eslint-config-isomorphic": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@moxy/eslint-config-isomorphic/-/eslint-config-isomorphic-1.0.0.tgz",
+      "integrity": "sha512-en6EBmZJLchGcpP6b/b4PIZc8Q0vYVWOrWtXbddYHzlCkuAcrZLweWNL3Xp60hn9qwyawPBsIkgaWufmy0h/6w==",
+      "dev": true,
+      "requires": {
+        "@moxy/eslint-config-browser": "^1.0.0",
+        "@moxy/eslint-config-node": "^1.0.0"
+      }
+    },
+    "@moxy/eslint-config-jest": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@moxy/eslint-config-jest/-/eslint-config-jest-1.0.0.tgz",
+      "integrity": "sha512-3/TpKu+zTq004tvUa6lsyTJme1izqx0VYfMIOxSGgBU/pUgoLt/UBfbZvC6B6yvyZN/4CCe7D+vEDaRVCoMzJA==",
+      "dev": true,
+      "requires": {
+        "@moxy/eslint-config-core": "^1.0.0",
+        "eslint-plugin-jest": "^23.0.4"
+      }
+    },
+    "@moxy/eslint-config-node": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@moxy/eslint-config-node/-/eslint-config-node-1.0.0.tgz",
+      "integrity": "sha512-JSIDcC+67/4pV0DnlR5bCHm/UeU24SRAhUuUNr9e+2qvaz6nVOmirwhaBluDia/L05wXtVtfpf16p3ILsPM5rw==",
+      "dev": true,
+      "requires": {
+        "@moxy/eslint-config-core": "^1.0.0"
+      }
+    },
+    "@moxy/eslint-config-react": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@moxy/eslint-config-react/-/eslint-config-react-1.0.0.tgz",
+      "integrity": "sha512-Hg5jLXh8tHjL4xj+0CfUNb5Lqp2OKTwPS4NoWvfmjjCK+ACgC2ptKo6hOlu7flNRiQvq6/yVt5hv8jRYFrCDPA==",
+      "dev": true,
+      "requires": {
+        "@moxy/eslint-config-core": "^1.0.0",
         "eslint-plugin-react": "^7.16.0",
-        "eslint-plugin-react-hooks": "^2.3.0",
-        "eslint-plugin-vue": "^6.1.2",
-        "prettier": "^1.19.1"
+        "eslint-plugin-react-hooks": "^2.3.0"
       }
     },
     "@moxy/jest-config": {
@@ -3004,13 +3047,13 @@
       "dev": true
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.22.0.tgz",
-      "integrity": "sha512-sJt1GYBe6yC0dWOQzXlp+tiuGglNhJC9eXZeC8GBVH98Zv9jtatccuhz0OF5kC/DwChqsNfghHx7OlIDQjNYAQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.23.0.tgz",
+      "integrity": "sha512-OswxY59RcXH3NNPmq+4Kis2CYZPurRU6mG5xPcn24CjFyfdVli5mySwZz/g/xDbJXgDsYqNGq7enV0IziWGXVQ==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.22.0",
+        "@typescript-eslint/typescript-estree": "2.23.0",
         "eslint-scope": "^5.0.0"
       },
       "dependencies": {
@@ -3027,9 +3070,9 @@
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.22.0.tgz",
-      "integrity": "sha512-2HFZW2FQc4MhIBB8WhDm9lVFaBDy6h9jGrJ4V2Uzxe/ON29HCHBTj3GkgcsgMWfsl2U5as+pTOr30Nibaw7qRQ==",
+      "version": "2.23.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.23.0.tgz",
+      "integrity": "sha512-pmf7IlmvXdlEXvE/JWNNJpEvwBV59wtJqA8MLAxMKLXNKVRC3HZBXR/SlZLPWTCcwOSg9IM7GeRSV3SIerGVqw==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -3047,15 +3090,6 @@
           "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         }
-      }
-    },
-    "@vue/eslint-config-prettier": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@vue/eslint-config-prettier/-/eslint-config-prettier-6.0.0.tgz",
-      "integrity": "sha512-wFQmv45c3ige5EA+ngijq40YpVcIkAy0Lihupnsnd1Dao5CBbPyfCzqtejFLZX1EwH/kCJdpz3t6s+5wd3+KxQ==",
-      "dev": true,
-      "requires": {
-        "eslint-config-prettier": "^6.0.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -8393,15 +8427,6 @@
         }
       }
     },
-    "eslint-config-prettier": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.10.0.tgz",
-      "integrity": "sha512-AtndijGte1rPILInUdHjvKEGbIV06NuvPrqlIEaEaWtbtvJh464mDeyGMdZEQMsGvC0ZVkiex1fSNcC4HAbRGg==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
-      }
-    },
     "eslint-plugin-babel": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.0.tgz",
@@ -8450,15 +8475,6 @@
       "integrity": "sha1-DfThF9opEJ71YdNV7Bn0HfCtpvY=",
       "dev": true
     },
-    "eslint-plugin-prettier": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-3.1.2.tgz",
-      "integrity": "sha512-GlolCC9y3XZfv3RQfwGew7NnuFDKsfI4lbvRK+PIIo23SFH+LemGs4cKwzAaRa+Mdb+lQO/STaIayno8T5sJJA==",
-      "dev": true,
-      "requires": {
-        "prettier-linter-helpers": "^1.0.0"
-      }
-    },
     "eslint-plugin-react": {
       "version": "7.19.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.19.0.tgz",
@@ -8492,17 +8508,6 @@
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.0.tgz",
       "integrity": "sha512-bzvdX47Jx847bgAYf0FPX3u1oxU+mKU8tqrpj4UX9A96SbAmj/HVEefEy6rJUog5u8QIlOPTKZcBpGn5kkKfAQ==",
       "dev": true
-    },
-    "eslint-plugin-vue": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-vue/-/eslint-plugin-vue-6.2.1.tgz",
-      "integrity": "sha512-MiIDOotoWseIfLIfGeDzF6sDvHkVvGd2JgkvjyHtN3q4RoxdAXrAMuI3SXTOKatljgacKwpNAYShmcKZa4yZzw==",
-      "dev": true,
-      "requires": {
-        "natural-compare": "^1.4.0",
-        "semver": "^5.6.0",
-        "vue-eslint-parser": "^7.0.0"
-      }
     },
     "eslint-rule-composer": {
       "version": "0.3.0",
@@ -8987,12 +8992,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
       "integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
-    },
-    "fast-diff": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.2.0.tgz",
-      "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
-      "dev": true
     },
     "fast-glob": {
       "version": "2.2.7",
@@ -9690,12 +9689,6 @@
           "dev": true
         }
       }
-    },
-    "get-stdin": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
-      "integrity": "sha512-jp4tHawyV7+fkkSKyvjuLZswblUtz+SQKzSWnBbii16BuZksJlU1wuBYXY75r+duh/llF1ur6oNwi+2ZzjKZ7g==",
-      "dev": true
     },
     "get-stream": {
       "version": "4.1.0",
@@ -11495,7 +11488,8 @@
           "dependencies": {
             "acorn": {
               "version": "6.4.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+              "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
               "dev": true
             }
           }
@@ -19454,21 +19448,6 @@
       "resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
       "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
     },
-    "prettier": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
-      "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
-      "dev": true
-    },
-    "prettier-linter-helpers": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz",
-      "integrity": "sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==",
-      "dev": true,
-      "requires": {
-        "fast-diff": "^1.1.2"
-      }
-    },
     "pretty-format": {
       "version": "25.1.0",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-25.1.0.tgz",
@@ -23241,32 +23220,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.2.tgz",
       "integrity": "sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ=="
-    },
-    "vue-eslint-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/vue-eslint-parser/-/vue-eslint-parser-7.0.0.tgz",
-      "integrity": "sha512-yR0dLxsTT7JfD2YQo9BhnQ6bUTLsZouuzt9SKRP7XNaZJV459gvlsJo4vT2nhZ/2dH9j3c53bIx9dnqU2prM9g==",
-      "dev": true,
-      "requires": {
-        "debug": "^4.1.1",
-        "eslint-scope": "^5.0.0",
-        "eslint-visitor-keys": "^1.1.0",
-        "espree": "^6.1.2",
-        "esquery": "^1.0.1",
-        "lodash": "^4.17.15"
-      },
-      "dependencies": {
-        "eslint-scope": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.0.0.tgz",
-          "integrity": "sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==",
-          "dev": true,
-          "requires": {
-            "esrecurse": "^4.1.0",
-            "estraverse": "^4.1.1"
-          }
-        }
-      }
     },
     "w3c-hr-time": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,9 @@
   "devDependencies": {
     "@commitlint/config-conventional": "^8.0.0",
     "@moxy/babel-preset": "^3.2.5",
-    "@moxy/eslint-config": "^10.1.0",
+    "@moxy/eslint-config-isomorphic": "^1.0.0",
+    "@moxy/eslint-config-jest": "^1.0.0",
+    "@moxy/eslint-config-react": "^1.0.0",
     "@moxy/jest-config": "^2.0.2",
     "@moxy/postcss-preset": "^4.4.2",
     "@moxy/stylelint-config": "^8.1.0",


### PR DESCRIPTION
Given the recent refactoring of [MOXY's eslint-config](https://github.com/moxystudio/eslint-config), this PR switches the `eslint` configuration used from the previous deprecated one to the current version.