### PR TITLE
fix: validate SITE_URL env var as a valid URL

### DIFF
--- a/.github/workflows/deploy-now.yml
+++ b/.github/workflows/deploy-now.yml
@@ -1,0 +1,35 @@
+name: Deploy on Zeit Now
+
+on:
+  push:
+    paths-ignore:
+      - docusaurus/**/*
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Deploy
+        id: deploy-now
+        env:
+          NOW_ORG_ID: team_p8EekuXu9HkFUEY7yLOeujBS
+          NOW_PROJECT_ID: QmYUpNNm3Aw2W2W59sdNwKdcNduZXXQGhNgc4crdtASxNZ
+          ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }}
+          BRANCH: ${{ github.base_ref }}
+          SITE_URL: https://next-with.moxy.tech
+        run: |
+          npx now \
+            -t $ZEIT_TOKEN \
+            --build-env SITE_URL=${SITE_URL} > .url.txt
+
+          echo "::set-output name=DEPLOYMENT_URL::$(cat .url.txt)"
+
+      - name: Comment deployment URL
+        uses: unsplash/comment-on-pr@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          msg: ${{ steps.deploy-now.outputs.DEPLOYMENT_URL }}

--- a/.github/workflows/deploy-now.yml
+++ b/.github/workflows/deploy-now.yml
@@ -5,6 +5,11 @@ on:
     paths-ignore:
       - docusaurus/**/*
 
+env:
+  NOW_ORG_ID: team_p8EekuXu9HkFUEY7yLOeujBS
+  NOW_PROJECT_ID: QmYUpNNm3Aw2W2W59sdNwKdcNduZXXQGhNgc4crdtASxNZ
+  ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }}
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -14,22 +19,40 @@ jobs:
 
       - name: Deploy
         id: deploy-now
+        if: github.ref != 'refs/heads/master'
         env:
-          NOW_ORG_ID: team_p8EekuXu9HkFUEY7yLOeujBS
-          NOW_PROJECT_ID: QmYUpNNm3Aw2W2W59sdNwKdcNduZXXQGhNgc4crdtASxNZ
-          ZEIT_TOKEN: ${{ secrets.ZEIT_TOKEN }}
-          BRANCH: ${{ github.base_ref }}
+          SITE_URL: https://next-with-moxy-${{ github.sha }}.now.sh
+        run: |
+          npx now \
+            -t $ZEIT_TOKEN \
+            --build-env SITE_URL=${SITE_URL} \
+            > .now-url
+
+          DEPLOYMENT_URL=$(cat .now-url)
+
+          npx now alias \
+            -t $ZEIT_TOKEN \
+            $DEPLOYMENT_URL \
+            $SITE_URL
+
+          echo "::set-output name=SITE_URL::$SITE_URL"
+
+      - name: Deploy master
+        id: deploy-now-master
+        if: github.ref == 'refs/heads/master'
+        env:
           SITE_URL: https://next-with.moxy.tech
         run: |
           npx now \
             -t $ZEIT_TOKEN \
-            --build-env SITE_URL=${SITE_URL} > .url.txt
+            --prod \
+            --build-env SITE_URL=${SITE_URL}
 
-          echo "::set-output name=DEPLOYMENT_URL::$(cat .url.txt)"
+          echo "::set-output name=SITE_URL::$SITE_URL"
 
-      - name: Comment deployment URL
+      - name: Comment URL
         uses: unsplash/comment-on-pr@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ github.token }}
         with:
-          msg: ${{ steps.deploy-now.outputs.DEPLOYMENT_URL }}
+          msg: "Deployed at Zeit Now: ${{ steps.deploy-now.outputs.SITE_URL || steps.deploy-now-master.outputs.SITE_URL }}"

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -8,10 +8,8 @@ on:
 env:
   DOCKER_REGISTRY: docker.pkg.github.com
   DOCKER_BUILDKIT: 1
-  SITE_URL: https://next-with.moxy.tech
 
 jobs:
-
   prepare:
     runs-on: ubuntu-latest
 
@@ -76,6 +74,7 @@ jobs:
     - name: Build image
       env:
         DOCKER_BASE_IMAGE: ${{ env.DOCKER_REGISTRY }}/moxystudio/next-with-moxy/base
+        SITE_URL: https://next-with.moxy.tech
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | docker login -u $GITHUB_ACTOR --password-stdin $DOCKER_REGISTRY
 

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -8,6 +8,7 @@ on:
 env:
   DOCKER_REGISTRY: docker.pkg.github.com
   DOCKER_BUILDKIT: 1
+  SITE_URL: http://localhost
 
 jobs:
 

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -8,7 +8,7 @@ on:
 env:
   DOCKER_REGISTRY: docker.pkg.github.com
   DOCKER_BUILDKIT: 1
-  SITE_URL: http://localhost
+  SITE_URL: https://next-with.moxy.tech
 
 jobs:
 
@@ -83,7 +83,8 @@ jobs:
         docker build . \
           --cache-from ${DOCKER_BASE_IMAGE}:latest \
           --target runtime  \
-          -t runtime:latest
+          -t runtime:latest \
+          --build-arg SITE_URL=${{ env.SITE_URL }}
 
     - name: Run image & check status code
       run: |

--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -74,7 +74,7 @@ jobs:
     - name: Build image
       env:
         DOCKER_BASE_IMAGE: ${{ env.DOCKER_REGISTRY }}/moxystudio/next-with-moxy/base
-        SITE_URL: https://next-with.moxy.tech
+        SITE_URL: http://localhost
       run: |
         echo ${{ secrets.GITHUB_TOKEN }} | docker login -u $GITHUB_ACTOR --password-stdin $DOCKER_REGISTRY
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -5,9 +5,6 @@ on:
     paths-ignore:
       - docusaurus/**/*
 
-env:
-    SITE_URL: https://next-with.moxy.tech
-
 jobs:
   prepare:
     runs-on: ubuntu-latest
@@ -94,6 +91,8 @@ jobs:
         npm ci
 
     - name: Build
+      env:
+        SITE_URL: https://next-with.moxy.tech
       run: |
         npm run build
 

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -5,8 +5,10 @@ on:
     paths-ignore:
       - docusaurus/**/*
 
-jobs:
+env:
+    SITE_URL: https://next-with.moxy.tech
 
+jobs:
   prepare:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -92,7 +92,7 @@ jobs:
 
     - name: Build
       env:
-        SITE_URL: https://next-with.moxy.tech
+        SITE_URL: http://localhost
       run: |
         npm run build
 

--- a/docusaurus/docs/what-is-included/environment-variables.md
+++ b/docusaurus/docs/what-is-included/environment-variables.md
@@ -51,6 +51,19 @@ if (process.env.FEATURE_A) {
     }
     ```
 
+    If you want to validate environment variables, we suggest you do it in this step. We suggest using [`@hapi/joi`](https://github.com/hapijs/joi) with its [`attempt`](https://github.com/hapijs/joi/blob/master/API.md#attemptvalue-schema-message-options) function, like the following example:
+    ```js
+    {
+        env: {
+            // ...
+            FEATURE_A: Joi.attempt(process.env.FEATURE_A, Joi.boolean()
+                .truthy('1')
+                .falsy('0')
+                .message('process.env.FEATURE_A must be one of "true", "1", "false", or "0".')),
+        },
+    }
+    ```
+
 3. Add it to the Dockerfile
 
     ```dockerfile

--- a/docusaurus/docs/what-is-included/environment-variables.md
+++ b/docusaurus/docs/what-is-included/environment-variables.md
@@ -51,7 +51,8 @@ if (process.env.FEATURE_A) {
     }
     ```
 
-    If you want to validate environment variables, we suggest you do it in this step. We suggest using [`@hapi/joi`](https://github.com/hapijs/joi) with its [`attempt`](https://github.com/hapijs/joi/blob/master/API.md#attemptvalue-schema-message-options) function, like the following example:
+    If you want to validate environment variables, we suggest you to use [`@hapi/joi`](https://github.com/hapijs/joi) with its [`attempt`](https://github.com/hapijs/joi/blob/master/API.md#attemptvalue-schema-message-options) function, like the following example:
+
     ```js
     {
         env: {
@@ -61,12 +62,14 @@ if (process.env.FEATURE_A) {
                 Joi.boolean()
                     .truthy('1')
                     .falsy('0')
-                    .required()
+                    .default(false)
                 'FEATURE_A - '
             ),
         },
     }
     ```
+
+    If your environment variable is mandatory, please use `.presence()` like `SITE_URL` is using.
 
 3. Add it to the Dockerfile
 

--- a/docusaurus/docs/what-is-included/environment-variables.md
+++ b/docusaurus/docs/what-is-included/environment-variables.md
@@ -56,10 +56,14 @@ if (process.env.FEATURE_A) {
     {
         env: {
             // ...
-            FEATURE_A: Joi.attempt(process.env.FEATURE_A, Joi.boolean()
-                .truthy('1')
-                .falsy('0')
-                .message('process.env.FEATURE_A must be one of "true", "1", "false", or "0".')),
+            FEATURE_A: Joi.attempt(
+                process.env.FEATURE_A,
+                Joi.boolean()
+                    .truthy('1')
+                    .falsy('0')
+                    .required()
+                'FEATURE_A - '
+            ),
         },
     }
     ```

--- a/next.config.js
+++ b/next.config.js
@@ -62,10 +62,13 @@ module.exports = (phase, nextConfig) =>
         compress: process.env.COMPRESSION !== '0',
         env: {
             GA_TRACKING_ID: process.env.GA_TRACKING_ID,
-            SITE_URL: Joi.attempt(process.env.SITE_URL,
+            SITE_URL: Joi.attempt(
+                process.env.SITE_URL,
                 Joi.string()
+                    .required()
                     .uri({ scheme: ['https', 'http'] })
-                    .pattern(/\/$/, { invert: true })
-                    .message('process.env.SITE_URL must be a valid URL')),
+                    .pattern(/\/$/, { invert: true }),
+                'SITE_URL - ',
+            ),
         },
     })(phase, nextConfig);

--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,7 @@ const withOneOf = require('@moxy/next-webpack-oneof');
 const withCompileNodeModules = require('@moxy/next-compile-node-modules');
 const withNextIntl = require('@moxy/next-intl/plugin');
 const withPlugins = require('next-compose-plugins');
+const Joi = require('@hapi/joi');
 
 module.exports = (phase, nextConfig) =>
     withPlugins([
@@ -61,6 +62,10 @@ module.exports = (phase, nextConfig) =>
         compress: process.env.COMPRESSION !== '0',
         env: {
             GA_TRACKING_ID: process.env.GA_TRACKING_ID,
-            SITE_URL: process.env.SITE_URL,
+            SITE_URL: Joi.attempt(process.env.SITE_URL,
+                Joi.string()
+                    .uri({ scheme: ['https', 'http'] })
+                    .pattern(/\/$/, { invert: true })
+                    .message('process.env.SITE_URL must be a valid URL')),
         },
     })(phase, nextConfig);

--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,9 @@ const withCompileNodeModules = require('@moxy/next-compile-node-modules');
 const withNextIntl = require('@moxy/next-intl/plugin');
 const withPlugins = require('next-compose-plugins');
 const Joi = require('@hapi/joi');
+const { PHASE_DEVELOPMENT_SERVER, PHASE_PRODUCTION_BUILD } = require('next/constants');
+
+const isRequired = (phase) => phase === PHASE_DEVELOPMENT_SERVER || phase === PHASE_PRODUCTION_BUILD ? 'required' : 'optional';
 
 module.exports = (phase, nextConfig) =>
     withPlugins([
@@ -65,7 +68,7 @@ module.exports = (phase, nextConfig) =>
             SITE_URL: Joi.attempt(
                 process.env.SITE_URL,
                 Joi.string()
-                    .required()
+                    .presence(isRequired(phase))
                     .uri({ scheme: ['https', 'http'] })
                     .pattern(/\/$/, { invert: true }),
                 'SITE_URL - ',

--- a/package-lock.json
+++ b/package-lock.json
@@ -2511,9 +2511,9 @@
       }
     },
     "@moxy/next-compile-node-modules": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@moxy/next-compile-node-modules/-/next-compile-node-modules-1.3.4.tgz",
-      "integrity": "sha512-+OJK2Izg6MdqdRhXdA4JrVL6EByEhY1Z02fVnLb2pBMQDxplWCxYSeoKyOj3ntydK7+lBWlnkmv0RZshwLlHvg=="
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@moxy/next-compile-node-modules/-/next-compile-node-modules-1.3.5.tgz",
+      "integrity": "sha512-pOAYM8/6NGbPm0BaNs19fvnKyctrqDX9Td4bz4cg7kcZiIDWzR8tipIAgaIRkA58XNb3lzKYsLt4UAX6Xwck/g=="
     },
     "@moxy/next-intl": {
       "version": "2.0.0",
@@ -11676,8 +11676,7 @@
           "dependencies": {
             "acorn": {
               "version": "6.4.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-              "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
+              "resolved": "",
               "dev": true
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1473,6 +1473,49 @@
       "resolved": "https://registry.npmjs.org/@formatjs/intl-utils/-/intl-utils-2.2.0.tgz",
       "integrity": "sha512-+Az7tR1av1DHZu9668D8uh9atT6vp+FFmEF8BrEssv0OqzpVjpVBGVmcgPzQP8k2PQjVlm/h2w8cTt0knn132w=="
     },
+    "@hapi/address": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.0.1.tgz",
+      "integrity": "sha512-0oEP5UiyV4f3d6cBL8F3Z5S7iWSX39Knnl0lY8i+6gfmmIBj44JCBNtcMgwyS+5v7j3VYavNay0NFHDS+UGQcw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "@hapi/formula": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
+      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A=="
+    },
+    "@hapi/hoek": {
+      "version": "9.0.4",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.0.4.tgz",
+      "integrity": "sha512-EwaJS7RjoXUZ2cXXKZZxZqieGtc7RbvQhUy8FwDoMQtxWVi14tFjeFCYPZAM1mBCpOpiBpyaZbb9NeHc7eGKgw=="
+    },
+    "@hapi/joi": {
+      "version": "17.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
+      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
+      "requires": {
+        "@hapi/address": "^4.0.1",
+        "@hapi/formula": "^2.0.0",
+        "@hapi/hoek": "^9.0.0",
+        "@hapi/pinpoint": "^2.0.0",
+        "@hapi/topo": "^5.0.0"
+      }
+    },
+    "@hapi/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-vzXR5MY7n4XeIvLpfl3HtE3coZYO4raKXW766R6DZw/6aLqR26iuZ109K7a0NtF2Db0jxqh7xz2AxkUwpUFybw=="
+    },
+    "@hapi/topo": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.0.0.tgz",
+      "integrity": "sha512-tFJlT47db0kMqVm3H4nQYgn6Pwg10GTZHb1pwmSiv1K4ks6drQOtfEF5ZnPjkvC+y4/bUPHK+bc87QvLcL+WMw==",
+      "requires": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
     "@istanbuljs/load-nyc-config": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@istanbuljs/load-nyc-config/-/load-nyc-config-1.0.0.tgz",
@@ -9569,10 +9612,7 @@
     "full-icu": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
-      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
-      "requires": {
-        "icu4c-data": "^0.64.2"
-      }
+      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw=="
     },
     "function-bind": {
       "version": "1.1.1",
@@ -10542,11 +10582,6 @@
           }
         }
       }
-    },
-    "icu4c-data": {
-      "version": "0.64.2",
-      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
-      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
     },
     "identity-obj-proxy": {
       "version": "3.0.0",
@@ -11633,7 +11668,8 @@
           "dependencies": {
             "acorn": {
               "version": "6.4.0",
-              "resolved": "",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
+              "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
               "dev": true
             }
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9612,7 +9612,10 @@
     "full-icu": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
-      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw=="
+      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -10582,6 +10585,11 @@
           }
         }
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
     },
     "identity-obj-proxy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "docs": "npm run start --prefix docusaurus -- --port 4000"
   },
   "dependencies": {
+    "@hapi/joi": "^17.1.1",
     "@moxy/next-common-files": "^1.2.1",
     "@moxy/next-compile-node-modules": "^1.3.2",
     "@moxy/next-intl": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@hapi/joi": "^17.1.1",
     "@moxy/next-common-files": "^1.2.1",
-    "@moxy/next-compile-node-modules": "^1.3.2",
+    "@moxy/next-compile-node-modules": "^1.3.5",
     "@moxy/next-intl": "^2.0.0",
     "@moxy/next-layout": "^2.1.2",
     "@moxy/next-webpack-oneof": "^1.0.2",


### PR DESCRIPTION
Implements validation to guarantee that `SITE_URL` is a valid URL. Currently, it only allows `http` for `localhost`, which might be too strict, so opinions welcome.

This implementation makes it so failure to validate will stop the app building process. 

This implementation also parallels the [`next-validation`](https://github.com/moxystudio/next-validation) package, which is made obsolete for this specific problem with this solution.