### PR TITLE
fix: datocms translations recipe

### DIFF
--- a/docusaurus/docs/recipes/dato-cms.md
+++ b/docusaurus/docs/recipes/dato-cms.md
@@ -211,7 +211,10 @@ const apolloClient = createApolloClient(null, null);
 const GET_TRANSLATIONS = gql`
     query Translations($locale: SiteLocale) {
         translation(locale: $locale) {
-            entries
+            entries {
+                key
+                value
+            }
         }
     }
 `;
@@ -231,7 +234,11 @@ export default {
 
                 const { translation } = result.data;
 
-                return translation.entries;
+                return translation.entries.reduce((map, obj) => {
+                    map[obj.key] = obj.value;
+
+                    return map;
+                }, {});
             },
         },
     ],


### PR DESCRIPTION
This PR aims to fix an misleading code recipe that is not correct for the usage of CMS translations, since the query and the following code for intl are expecting an object of translations coming from CMS when it should be an array of objects containing keys and values. 