### PR TITLE
chore: add custom render

### DIFF
--- a/docusaurus/static/recipes-assets/react-splash-screen/SplashScreen.test.js
+++ b/docusaurus/static/recipes-assets/react-splash-screen/SplashScreen.test.js
@@ -1,50 +1,49 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import WaitForReact from '@moxy/react-wait-for-react';
 import SplashScreen from './SplashScreen';
-import AppTree from '../../test-utils/modules/react-app-tree';
+import { render, screen } from 'test-utils';
 
 jest.mock('@moxy/react-wait-for-react', () => jest.fn(() => null));
 
 it('should render the content and progress bar correctly when progress is 0', () => {
     WaitForReact.mockImplementationOnce(({ children }) => children({ progress: 0, error: undefined }));
 
-    const { container } = render(<AppTree><SplashScreen /></AppTree>);
+    const { getByDataWaitForReactElement } = render(<SplashScreen />);
 
-    expect(container).not.toHaveTextContent('error');
-    expect(container.querySelector('[data-wait-for-react-element="progressBar"]')).toHaveStyle({ transform: 'scaleX(0)' });
-    expect(container.querySelector('[data-wait-for-react-element="splashScreen"]')).not.toHaveClass('loading', 'loaded');
+    expect(screen.getByText('error')).not.toBeInTheDocument();
+    expect(getByDataWaitForReactElement('progressBar')).toHaveStyle({ transform: 'scaleX(0)' });
+    expect(getByDataWaitForReactElement('splashScreen')).not.toHaveClass('loading', 'loaded');
 });
 
 it('should render the content and progress bar correctly when progress is between 0 and 1', () => {
     WaitForReact.mockImplementationOnce(({ children }) => children({ progress: 0.2, error: undefined }));
 
-    const { container } = render(<AppTree><SplashScreen /></AppTree>);
+    const { getByDataWaitForReactElement } = render(<SplashScreen />);
 
-    expect(container).not.toHaveTextContent('error');
-    expect(container.querySelector('[data-wait-for-react-element="progressBar"]')).toHaveStyle({ transform: 'scaleX(0.2)' });
-    expect(container.querySelector('[data-wait-for-react-element="splashScreen"]')).toHaveClass('loading');
-    expect(container.querySelector('[data-wait-for-react-element="splashScreen"]')).not.toHaveClass('loaded');
+    expect(screen.getByText('error')).not.toBeInTheDocument();
+    expect(getByDataWaitForReactElement('progressBar')).toHaveStyle({ transform: 'scaleX(0.2)' });
+    expect(getByDataWaitForReactElement('splashScreen')).toHaveClass('loading');
+    expect(getByDataWaitForReactElement('splashScreen')).not.toHaveClass('loaded');
 });
 
 it('should render the content and progress bar correctly when progress is 1', () => {
     WaitForReact.mockImplementationOnce(({ children }) => children({ progress: 1, error: undefined }));
 
-    const { container } = render(<AppTree><SplashScreen /></AppTree>);
+    const { getByDataWaitForReactElement } = render(<SplashScreen />);
 
-    expect(container).not.toHaveTextContent('error');
-    expect(container.querySelector('[data-wait-for-react-element="progressBar"]')).toHaveStyle({ transform: 'scaleX(1)' });
-    expect(container.querySelector('[data-wait-for-react-element="splashScreen"]')).toHaveClass('loaded');
-    expect(container.querySelector('[data-wait-for-react-element="splashScreen"]')).not.toHaveClass('loading');
+    expect(screen.getByText('error')).not.toBeInTheDocument();
+    expect(getByDataWaitForReactElement('progressBar')).toHaveStyle({ transform: 'scaleX(1)' });
+    expect(getByDataWaitForReactElement('splashScreen')).toHaveClass('loaded');
+    expect(getByDataWaitForReactElement('splashScreen')).not.toHaveClass('loading');
 });
 
 it('should render an error if the promise failed', () => {
     WaitForReact.mockImplementationOnce(({ children }) => children({ progress: 0.2, error: new Error('foo') }));
 
-    const { container } = render(<AppTree><SplashScreen /></AppTree>);
+    const { getByDataWaitForReactElement } = render(<SplashScreen />);
 
-    expect(container).toHaveTextContent('error');
-    expect(container.querySelector('[data-wait-for-react-element="progressBar"]')).toHaveStyle({ transform: 'scaleX(0.2)' });
-    expect(container.querySelector('[data-wait-for-react-element="splashScreen"]')).toHaveClass('loading');
-    expect(container.querySelector('[data-wait-for-react-element="splashScreen"]')).not.toHaveClass('loaded');
+    expect(screen.getByText('error')).toBeInTheDocument();
+    expect(getByDataWaitForReactElement('progressBar')).toHaveStyle({ transform: 'scaleX(0.2)' });
+    expect(getByDataWaitForReactElement('splashScreen')).toHaveClass('loading');
+    expect(getByDataWaitForReactElement('splashScreen')).not.toHaveClass('loaded');
 });

--- a/www/app/App.test.js
+++ b/www/app/App.test.js
@@ -1,9 +1,8 @@
 import React, { useEffect } from 'react';
-import { render } from '@testing-library/react';
 import { App } from './App';
+import { render, screen } from '../shared/test-utils';
 import CookieBanner from '../shared/modules/react-cookie-banner';
 import { initGTM, destroyGTM } from '../shared/utils/google-tag-manager';
-import { AppTreeWrapper } from '../shared/test-utils/modules/react-app-tree';
 
 jest.mock('../shared/modules/react-cookie-banner', () => jest.fn(() => null));
 
@@ -29,13 +28,9 @@ beforeEach(() => {
 });
 
 it('should render correctly', () => {
-    const { container } = render(
-        <AppTreeWrapper>
-            <App Component={ () => 'Hello World' } />
-        </AppTreeWrapper>,
-    );
+    render(<App Component={ () => 'Hello World' } />);
 
-    expect(container).toHaveTextContent('Hello World');
+    expect(screen.getByText('Hello World')).toBeInTheDocument();
 });
 
 describe('GTM', () => {
@@ -48,11 +43,7 @@ describe('GTM', () => {
             return null;
         });
 
-        render(
-            <AppTreeWrapper>
-                <App Component={ () => 'Hello World' } />
-            </AppTreeWrapper>,
-        );
+        render(<App Component={ () => 'Hello World' } />);
 
         expect(initGTM).toHaveBeenCalledTimes(1);
         expect(destroyGTM).toHaveBeenCalledTimes(0);
@@ -67,11 +58,7 @@ describe('GTM', () => {
             return null;
         });
 
-        render(
-            <AppTreeWrapper>
-                <App Component={ () => 'Hello World' } />
-            </AppTreeWrapper>,
-        );
+        render(<App Component={ () => 'Hello World' } />);
 
         expect(initGTM).toHaveBeenCalledTimes(0);
         expect(destroyGTM).toHaveBeenCalledTimes(1);

--- a/www/pages/contacts/Contacts.test.js
+++ b/www/pages/contacts/Contacts.test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import Contacts from './Contacts';
-import AppTree from '../../shared/test-utils/modules/react-app-tree';
+import { render, screen } from '../../shared/test-utils';
 
 it('should render correctly', () => {
-    const { container } = render(<AppTree><Contacts /></AppTree>);
+    render(<Contacts />);
 
-    expect(container).toHaveTextContent('contacts.title');
+    expect(screen.getByText('contacts.title')).toBeInTheDocument();
 });

--- a/www/pages/contacts/project-info/ProjectInfo.test.js
+++ b/www/pages/contacts/project-info/ProjectInfo.test.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import ProjectInfo from './ProjectInfo';
-import AppTree from '../../../shared/test-utils/modules/react-app-tree';
+import { render, screen } from '../../../shared/test-utils';
 
 it('should render correctly', () => {
-    const { container } = render(<AppTree><ProjectInfo name="foo" email="bar" /></AppTree>);
+    render(<ProjectInfo name="foo" email="bar" />);
 
-    expect(container).toHaveTextContent('contacts.name');
-    expect(container).toHaveTextContent('contacts.email');
+    expect(screen.getByText('contacts.name')).toBeInTheDocument();
+    expect(screen.getByText('contacts.email')).toBeInTheDocument();
 });

--- a/www/pages/error/ErrorPage.test.js
+++ b/www/pages/error/ErrorPage.test.js
@@ -1,25 +1,20 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import ErrorPage from './ErrorPage';
-import AppTree from '../../shared/test-utils/modules/react-app-tree';
+import { render, screen } from '../../shared/test-utils';
 
 it('should render internal server error when `statusCode` is not 404', () => {
-    const { getByText } = render(
-        <AppTree>
-            <ErrorPage statusCode={ 500 } />
-        </AppTree>,
-    );
+    render(<ErrorPage statusCode={ 500 } />);
+
+    const { getByText } = screen;
 
     expect(getByText('error.internal.title')).toBeInTheDocument();
     expect(getByText('error.return-to-home')).toBeInTheDocument();
 });
 
 it('should render not found error when `statusCode` is 404', () => {
-    const { getByText } = render(
-        <AppTree>
-            <ErrorPage statusCode={ 404 } />
-        </AppTree>,
-    );
+    render(<ErrorPage statusCode={ 404 } />);
+
+    const { getByText } = screen;
 
     expect(getByText('error.not-found.title')).toBeInTheDocument();
     expect(getByText('error.return-to-home')).toBeInTheDocument();

--- a/www/pages/home/Home.test.js
+++ b/www/pages/home/Home.test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import Home from './Home';
-import AppTree from '../../shared/test-utils/modules/react-app-tree';
+import { render, screen } from '../../shared/test-utils';
 
 it('should render correctly', () => {
-    const { container } = render(<AppTree><Home /></AppTree>);
+    render(<Home />);
 
-    expect(container).toHaveTextContent('home.title');
+    expect(screen.getByText('home.title')).toBeInTheDocument();
 });

--- a/www/pages/terms/Terms.test.js
+++ b/www/pages/terms/Terms.test.js
@@ -1,10 +1,9 @@
 import React from 'react';
-import { render } from '@testing-library/react';
-import Home from './Terms';
-import AppTree from '../../shared/test-utils/modules/react-app-tree';
+import Terms from './Terms';
+import { render, screen } from '../../shared/test-utils';
 
 it('should render correctly', () => {
-    const { container } = render(<AppTree><Home /></AppTree>);
+    render(<Terms />);
 
-    expect(container).toHaveTextContent('terms.title');
+    expect(screen.getByText('terms.title')).toBeInTheDocument();
 });

--- a/www/shared/modules/react-cookie-banner/CookieBanner.test.js
+++ b/www/shared/modules/react-cookie-banner/CookieBanner.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react';
 import { CookieBanner } from './CookieBanner';
-import AppTree from '../../test-utils/modules/react-app-tree';
+import { render, fireEvent, screen } from '../../test-utils';
 
 afterEach(() => {
     jest.resetAllMocks();
@@ -11,9 +10,7 @@ it('should not render banner when banner was previously dismissed', () => {
     jest.spyOn(document, 'cookie', 'get').mockImplementation(() => 'cookieBannerDismissed=true');
 
     const { container } = render(
-        <AppTree>
-            <CookieBanner onCookieConsents={ () => {} } />
-        </AppTree>,
+        <CookieBanner onCookieConsents={ () => {} } />,
     );
 
     expect(container.innerHTML).toBe('');
@@ -23,22 +20,16 @@ it('should not render banner if there\'s at least one consent', () => {
     jest.spyOn(document, 'cookie', 'get').mockImplementation(() => 'cookieConsents=%5B%22analytics%22%5D');
 
     const { container } = render(
-        <AppTree>
-            <CookieBanner onCookieConsents={ () => {} } />
-        </AppTree>,
+        <CookieBanner onCookieConsents={ () => {} } />,
     );
 
     expect(container.innerHTML).toBe('');
 });
 
 it('should render if not dismissed and no consent was given', () => {
-    const { container } = render(
-        <AppTree>
-            <CookieBanner onCookieConsents={ () => {} } />
-        </AppTree>,
-    );
+    render(<CookieBanner onCookieConsents={ () => {} } />);
 
-    expect(container).toHaveTextContent('cookieBanner');
+    expect(screen.getByText('cookieBanner.text')).toBeInTheDocument();
 });
 
 it('should call onCookieConsents with the correct consents on mount', () => {
@@ -47,9 +38,7 @@ it('should call onCookieConsents with the correct consents on mount', () => {
     const handleCookieConsents = jest.fn();
 
     render(
-        <AppTree>
-            <CookieBanner onCookieConsents={ handleCookieConsents } />
-        </AppTree>,
+        <CookieBanner onCookieConsents={ handleCookieConsents } />,
     );
 
     expect(handleCookieConsents).toHaveBeenCalledTimes(1);
@@ -59,9 +48,7 @@ it('should call onCookieConsents with the correct consents on mount', () => {
     jest.spyOn(document, 'cookie', 'get').mockImplementation(() => '');
 
     render(
-        <AppTree>
-            <CookieBanner onCookieConsents={ handleCookieConsents } />
-        </AppTree>,
+        <CookieBanner onCookieConsents={ handleCookieConsents } />,
     );
 
     expect(handleCookieConsents).toHaveBeenCalledTimes(1);
@@ -72,9 +59,7 @@ it('should behave well when the accept button is clicked', () => {
     const handleCookieConsents = jest.fn();
 
     const { container, rerender, getByText } = render(
-        <AppTree>
-            <CookieBanner onCookieConsents={ handleCookieConsents } />
-        </AppTree>,
+        <CookieBanner onCookieConsents={ handleCookieConsents } />,
     );
 
     handleCookieConsents.mockClear();
@@ -87,38 +72,32 @@ it('should behave well when the accept button is clicked', () => {
     handleCookieConsents.mockClear();
 
     rerender(
-        <AppTree>
-            <CookieBanner onCookieConsents={ handleCookieConsents } />
-        </AppTree>,
+        <CookieBanner onCookieConsents={ handleCookieConsents } />,
     );
 
-    expect(handleCookieConsents).toHaveBeenCalledTimes(0);
+    expect(handleCookieConsents).not.toHaveBeenCalled();
     expect(container.innerHTML).toBe('');
 });
 
 it('should behave well when the reject button is clicked', () => {
     const handleCookieConsents = jest.fn();
 
-    const { container, rerender, getByText } = render(
-        <AppTree>
-            <CookieBanner onCookieConsents={ handleCookieConsents } />
-        </AppTree>,
+    const { container, rerender } = render(
+        <CookieBanner onCookieConsents={ handleCookieConsents } />,
     );
 
     expect(container.innerHTML).not.toBe('');
 
     handleCookieConsents.mockClear();
 
-    fireEvent.click(getByText('cookieBanner.reject'));
+    fireEvent.click(screen.getByText('cookieBanner.reject'));
 
-    expect(handleCookieConsents).toHaveBeenCalledTimes(0);
+    expect(handleCookieConsents).not.toHaveBeenCalled();
 
     rerender(
-        <AppTree>
-            <CookieBanner onCookieConsents={ handleCookieConsents } />
-        </AppTree>,
+        <CookieBanner onCookieConsents={ handleCookieConsents } />,
     );
 
-    expect(handleCookieConsents).toHaveBeenCalledTimes(0);
+    expect(handleCookieConsents).not.toHaveBeenCalled();
     expect(container.innerHTML).toBe('');
 });

--- a/www/shared/modules/react-footer/Footer.test.js
+++ b/www/shared/modules/react-footer/Footer.test.js
@@ -1,24 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import Footer from './Footer';
-import AppTree from '../../test-utils/modules/react-app-tree';
+import { render } from '../../test-utils';
 
 it('should render correctly', () => {
-    const { container } = render((
-        <AppTree>
-            <Footer />
-        </AppTree>
-    ));
+    const { container } = render(<Footer />);
 
     expect(container.querySelector('footer')).toBeInTheDocument();
 });
 
 it('should respect passed className', () => {
-    const { container } = render((
-        <AppTree>
-            <Footer className="foo" />
-        </AppTree>
-    ));
+    const { container } = render(<Footer className="foo" />);
 
     expect(container.querySelector('footer')).toHaveClass('foo');
 });

--- a/www/shared/modules/react-header/Header.test.js
+++ b/www/shared/modules/react-header/Header.test.js
@@ -1,24 +1,15 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import Header from './Header';
-import AppTree from '../../test-utils/modules/react-app-tree';
+import { render } from '../../test-utils';
 
 it('should render correctly', () => {
-    const { container } = render((
-        <AppTree>
-            <Header />
-        </AppTree>
-    ));
+    const { container } = render(<Header />);
 
     expect(container.querySelector('header')).toBeInTheDocument();
 });
 
 it('should respect passed className', () => {
-    const { container } = render((
-        <AppTree>
-            <Header className="foo" />
-        </AppTree>
-    ));
+    const { container } = render(<Header className="foo" />);
 
     expect(container.querySelector('header')).toHaveClass('foo');
 });

--- a/www/shared/modules/react-main-layout/MainLayout.test.js
+++ b/www/shared/modules/react-main-layout/MainLayout.test.js
@@ -1,16 +1,13 @@
 import React from 'react';
-import { render } from '@testing-library/react';
 import MainLayout from './MainLayout';
-import AppTree from '../../test-utils/modules/react-app-tree';
+import { render } from '../../test-utils';
 
 it('should render correctly', () => {
-    const { container } = render((
-        <AppTree>
-            <MainLayout>
-                <p className="hello">Hello!</p>
-            </MainLayout>
-        </AppTree>
-    ));
+    const { container } = render(
+        <MainLayout>
+            <p className="hello">Hello!</p>
+        </MainLayout>,
+    );
 
     expect(container.querySelector('header')).toBeInTheDocument();
     expect(container.querySelector('footer')).toBeInTheDocument();

--- a/www/shared/test-utils/index.js
+++ b/www/shared/test-utils/index.js
@@ -1,0 +1,16 @@
+import { render, queries } from '@testing-library/react';
+import AppTree from './modules/react-app-tree';
+import * as customQueries from './modules/custom-queries';
+
+const customRender = (ui, options) =>
+    render(ui, {
+        wrapper: AppTree,
+        queries: { ...queries, ...customQueries },
+        ...options,
+    });
+
+// re-export everything
+export * from '@testing-library/react';
+
+// Override render method
+export { customRender as render };

--- a/www/shared/test-utils/modules/custom-queries/custom-queries.js
+++ b/www/shared/test-utils/modules/custom-queries/custom-queries.js
@@ -1,0 +1,29 @@
+import { queryHelpers, buildQueries } from '@testing-library/react';
+
+// The queryAllByAttribute is a shortcut for attribute-based matchers
+// You can also use document.querySelector or a combination of existing
+// testing library utilities to find matching nodes for your query
+const queryAllByDataWaitForReactElement = (...args) =>
+    queryHelpers.queryAllByAttribute('data-wait-for-react-element', ...args);
+
+const getMultipleError = (c, dataWaitForReactElement) =>
+  `Found multiple elements with the data-wait-for-react-element attribute of: ${dataWaitForReactElement}`;
+const getMissingError = (c, dataWaitForReactElement) =>
+  `Unable to find an element with the data-wait-for-react-element attribute of: ${dataWaitForReactElement}`;
+
+const [
+    queryByDataWaitForReactElement,
+    getAllByDataWaitForReactElement,
+    getByDataWaitForReactElement,
+    findAllByDataWaitForReactElement,
+    findByDataWaitForReactElement,
+] = buildQueries(queryAllByDataWaitForReactElement, getMultipleError, getMissingError);
+
+export {
+    queryByDataWaitForReactElement,
+    queryAllByDataWaitForReactElement,
+    getByDataWaitForReactElement,
+    getAllByDataWaitForReactElement,
+    findByDataWaitForReactElement,
+    findAllByDataWaitForReactElement,
+};

--- a/www/shared/test-utils/modules/custom-queries/index.js
+++ b/www/shared/test-utils/modules/custom-queries/index.js
@@ -1,0 +1,1 @@
+export * from './custom-queries';

--- a/www/shared/test-utils/modules/react-app-tree/AppTree.test.js
+++ b/www/shared/test-utils/modules/react-app-tree/AppTree.test.js
@@ -1,26 +1,26 @@
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
-import { render } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import AppTree from './AppTree';
 
 it('should render children correctly', () => {
-    const { container } = render(
+    render(
         <AppTree>
             <div>foo</div>
         </AppTree>,
     );
 
-    expect(container).toHaveTextContent('foo');
+    expect(screen.getByText('foo')).toBeInTheDocument();
 });
 
 it('should correctly setup IntlProvider', () => {
-    const { container } = render(
+    render(
         <AppTree>
             <FormattedMessage id="foo" />
         </AppTree>,
     );
 
-    expect(container).toHaveTextContent('foo');
+    expect(screen.getByText('foo')).toBeInTheDocument();
 });
 
 it('should correctly setup IntlProvider with overrides', () => {
@@ -28,11 +28,11 @@ it('should correctly setup IntlProvider with overrides', () => {
         messages: { foo: 'bar' },
     };
 
-    const { container } = render(
+    render(
         <AppTree intlProvider={ intlProvider }>
             <FormattedMessage id="foo" />
         </AppTree>,
     );
 
-    expect(container).toHaveTextContent('bar');
+    expect(screen.getByText('bar')).toBeInTheDocument();
 });


### PR DESCRIPTION
This PR will add a `customRender` function which is able to wrap a desired component into all the necessary providers (and anything else it needs). Note that this approach is recommended by the RTL's [documentation](https://testing-library.com/docs/react-testing-library/setup#custom-render).

I also took this opportunity to refactor some tests which were using the `container` property from a `render` instead of `screen` ([as suggested here](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library#not-using-screen))

Motivation: https://github.com/moxystudio/react-native-with-moxy/pull/42#pullrequestreview-432694206