### PR TITLE
fix: fix bold font weights in firefox drawing bolder than specified

### DIFF
--- a/www/shared/styles/global/typography.css
+++ b/www/shared/styles/global/typography.css
@@ -13,6 +13,7 @@ body {
     @mixin text-smooth;
 
     color: var(--color-black);
+    -moz-osx-font-smoothing: grayscale; /* Corrects issue where Firefox draws bold font-weights as weightier than told to */
     overflow-wrap: break-word;  /* Break long words by default */
     -webkit-tap-highlight-color: transparent;  /* Do not show a highlight (rectangle around the link) while tapping it */
 }


### PR DESCRIPTION
Firefox sometimes draws fonts bolder than specified in styles rules. This is an old issue but still seems to be happening, for example:

- without the fix:
<img width="555" alt="image example of no fix" src="https://user-images.githubusercontent.com/25612626/85129951-ee535d00-b22b-11ea-850a-d08642d2d705.png">

- whereas it should be:
<img width="553" alt="Screenshot 2020-06-19 at 12 52 48" src="https://user-images.githubusercontent.com/25612626/85130017-0a56fe80-b22c-11ea-923e-2128225fd279.png">

Further information can be found in [this bug report](https://bugzilla.mozilla.org/show_bug.cgi?id=857142) discussing the implementation of this CSS rule.