### PR TITLE
fix: remove outline from unstyled-button mixin

### DIFF
--- a/www/shared/styles/imports/mixins/unstyled-button.css
+++ b/www/shared/styles/imports/mixins/unstyled-button.css
@@ -1,16 +1,8 @@
 @define-mixin unstyled-button {
     padding: 0;
     border: none;
-    outline-style: none;
     background: transparent;
     border-radius: 0;
     cursor: pointer;
     appearance: none;
-
-    &:active,
-    &:focus,
-    &:visited,
-    &:hover {
-        outline: none;
-    }
 }


### PR DESCRIPTION
We don't need to remove the `outline` as it is already handled by the [`react-keyboard-only-outlines`](https://github.com/moxystudio/react-keyboard-only-outlines) package.