### PR TITLE
fix: fix sidebar icon color for dark theme

### DIFF
--- a/docusaurus/src/css/custom.css
+++ b/docusaurus/src/css/custom.css
@@ -103,3 +103,11 @@ html[data-theme="dark"] .navbar.navbar .navbar-sidebar .navbar__brand .navbar__l
         max-width: 38px;
     }
 }
+
+/* ==========================================================================
+   Sidebar tweaks
+   ========================================================================== */
+
+html[data-theme="dark"] [class^="sidebarLogo_"] > img {
+    filter: brightness(0) invert(1);
+}


### PR DESCRIPTION
This PR will fix the sidebar icon color for dark theme. It will white now, to help with the visibility.