### PR TITLE
Update next-compile-node-modules dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3743,9 +3743,9 @@
       }
     },
     "@moxy/next-compile-node-modules": {
-      "version": "1.3.5",
-      "resolved": "https://registry.npmjs.org/@moxy/next-compile-node-modules/-/next-compile-node-modules-1.3.5.tgz",
-      "integrity": "sha512-pOAYM8/6NGbPm0BaNs19fvnKyctrqDX9Td4bz4cg7kcZiIDWzR8tipIAgaIRkA58XNb3lzKYsLt4UAX6Xwck/g=="
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/@moxy/next-compile-node-modules/-/next-compile-node-modules-1.3.6.tgz",
+      "integrity": "sha512-LkytLMgVHEleOSs9wj5HkhlHxI3uvgEQLAxCssZyvQKzDuUxqd9Z9byX+PTkZJMaRqn3cw8OjPlFhOYRDF+gbA=="
     },
     "@moxy/next-intl": {
       "version": "2.0.2",
@@ -10862,7 +10862,10 @@
     "full-icu": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/full-icu/-/full-icu-1.3.1.tgz",
-      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw=="
+      "integrity": "sha512-VMtK//85QJomhk3cXOCksNwOYaw1KWnYTS37GYGgyf7A3ajdBoPGhaJuJWAH2S2kq8GZeXkdKn+3Mfmgy11cVw==",
+      "requires": {
+        "icu4c-data": "^0.64.2"
+      }
     },
     "function-bind": {
       "version": "1.1.1",
@@ -11983,6 +11986,11 @@
           }
         }
       }
+    },
+    "icu4c-data": {
+      "version": "0.64.2",
+      "resolved": "https://registry.npmjs.org/icu4c-data/-/icu4c-data-0.64.2.tgz",
+      "integrity": "sha512-BPuTfkRTkplmK1pNrqgyOLJ0qB2UcQ12EotVLwiWh4ErtZR1tEYoRZk/LBLmlDfK5v574/lQYLB4jT9vApBiBQ=="
     },
     "identity-obj-proxy": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@hapi/joi": "^17.1.1",
     "@moxy/next-common-files": "^1.2.1",
-    "@moxy/next-compile-node-modules": "^1.3.5",
+    "@moxy/next-compile-node-modules": "^1.3.6",
     "@moxy/next-intl": "^2.0.0",
     "@moxy/next-layout": "^2.1.2",
     "@moxy/next-scroll-behavior": "^1.0.1",


### PR DESCRIPTION
`npm run dev` is throwing the following error:

![image](https://user-images.githubusercontent.com/2727522/87705615-13d57700-c796-11ea-8774-3f03dd8c0ccf.png)

When https://github.com/moxystudio/next-compile-node-modules/pull/10 was merged and released on v1.3.6, the dependency's version was not updated accordingly in the boilerplate. This PR fixes that.

CC @ruimonteiro93
