### PR TITLE
chore: add user-event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4306,9 +4306,9 @@
       }
     },
     "@testing-library/user-event": {
-      "version": "12.1.3",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.3.tgz",
-      "integrity": "sha512-U6tpKWbBMvqt8tIF77crr9VyP1W+yxK+c48xH5rvYwmT4MER5jvWAFqNzkn542Bt3qeDCn0aqwb0Pv+3mDbLtw==",
+      "version": "12.1.7",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-12.1.7.tgz",
+      "integrity": "sha512-wuJiPqSQTVIHsYuumv1PAOBjblSrYA5vyN1nkUDF5HgfuWGz44jQsO22u7PQNkuACGYJE4eU0sybX8CzsySv+Q==",
       "dev": true,
       "requires": {
         "@babel/runtime": "^7.10.2"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@moxy/postcss-preset": "^4.4.2",
     "@moxy/stylelint-config": "^8.1.0",
     "@testing-library/react": "^10.4.9",
-    "@testing-library/user-event": "^12.1.3",
+    "@testing-library/user-event": "^12.1.7",
     "commitlint": "^9.1.2",
     "eslint": "^7.7.0",
     "husky": "^4.2.0",


### PR DESCRIPTION
This PR will add [user-event](https://testing-library.com/docs/ecosystem-user-event) which is a companion library for Testing Library that provides more advanced simulation of browser interactions than the built-in fireEvent method.

Example:

```js
import { screen } from '@testing-library/dom'
import userEvent from '@testing-library/user-event'

test('types inside textarea', async () => {
  document.body.innerHTML = `<textarea />`

  await userEvent.type(screen.getByRole('textbox'), 'Hello, World!')
  expect(screen.getByRole('textbox')).toHaveValue('Hello, World!')
})
```

Note that using `fireEvent` the syntax for changing an input value isn't as readable:
`fireEvent.change(input, { target: { value: 'foo' } })`
