### PR TITLE
chore(cookies): fix plural wording

### DIFF
--- a/www/app/App.js
+++ b/www/app/App.js
@@ -18,8 +18,8 @@ import { seoData } from './App.data.js';
 export const AppInner = ({ Component, pageProps }) => {
     const pageKey = usePageKey();
 
-    const handleCookieConsents = useCallback((cookieConsents) => {
-        if (cookieConsents.includes('analytics')) {
+    const handleCookiesConsent = useCallback((cookiesConsent) => {
+        if (cookiesConsent.includes('analytics')) {
             initGTM();
         } else {
             destroyGTM();
@@ -44,7 +44,7 @@ export const AppInner = ({ Component, pageProps }) => {
             <Seo data={ seoData } />
 
             <KeyboardOnlyOutlines />
-            <CookieBanner onCookieConsents={ handleCookieConsents } />
+            <CookieBanner onCookiesConsent={ handleCookiesConsent } />
 
             <LayoutTree
                 Component={ Component }

--- a/www/app/App.test.js
+++ b/www/app/App.test.js
@@ -29,10 +29,10 @@ it('should render correctly (inner)', () => {
 
 describe('GTM', () => {
     it('should initialize GTM if analytics is in the cookies consent', () => {
-        CookieBanner.mockImplementation(({ onCookieConsents }) => {
+        CookieBanner.mockImplementation(({ onCookiesConsent }) => {
             useEffect(() => {
-                onCookieConsents(['analytics']);
-            }, [onCookieConsents]);
+                onCookiesConsent(['analytics']);
+            }, [onCookiesConsent]);
 
             return null;
         });
@@ -44,10 +44,10 @@ describe('GTM', () => {
     });
 
     it('should destroy GTM if analytics is not on the cookies consent', () => {
-        CookieBanner.mockImplementation(({ onCookieConsents }) => {
+        CookieBanner.mockImplementation(({ onCookiesConsent }) => {
             useEffect(() => {
-                onCookieConsents(['foo']);
-            }, [onCookieConsents]);
+                onCookiesConsent(['foo']);
+            }, [onCookiesConsent]);
 
             return null;
         });

--- a/www/shared/modules/react-cookie-banner/CookieBanner.js
+++ b/www/shared/modules/react-cookie-banner/CookieBanner.js
@@ -6,21 +6,21 @@ import Link from 'next/link';
 
 import styles from './CookieBanner.module.css';
 
-const CookieBanner = ({ onCookieConsents }) => {
+const CookieBanner = ({ onCookiesConsent }) => {
     const [mounted, setMounted] = useState(false);
-    const [cookies, setCookie] = useCookies(['cookieConsents', 'cookieBannerDismissed']);
+    const [cookies, setCookie] = useCookies(['cookiesConsent', 'cookieBannerDismissed']);
 
-    const { cookieConsents = [], cookieBannerDismissed = false } = cookies;
+    const { cookiesConsent = [], cookieBannerDismissed = false } = cookies;
 
     useEffect(() => setMounted(true), []);
 
     useEffect(() => {
-        onCookieConsents(cookieConsents);
+        onCookiesConsent(cookiesConsent);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [onCookieConsents, cookieConsents.join(',')]);
+    }, [onCookiesConsent, cookiesConsent.join(',')]);
 
     const handleAcceptClick = useCallback(() => {
-        setCookie('cookieConsents', ['analytics'], { maxAge: 365 * 24 * 60 * 60 });
+        setCookie('cookiesConsent', ['analytics'], { maxAge: 365 * 24 * 60 * 60 });
     }, [setCookie]);
 
     const handleRejectClick = useCallback(() => {
@@ -30,7 +30,7 @@ const CookieBanner = ({ onCookieConsents }) => {
     // Do not display banner if:
     // - user has previously dismissed or accepted at least one consent
     // - on SSR to avoid having to add "Vary: Cookie" to the response headers, which is bad for reverse proxy caches
-    if (!mounted || cookieBannerDismissed || cookieConsents.length > 0) {
+    if (!mounted || cookieBannerDismissed || cookiesConsent.length > 0) {
         return null;
     }
 
@@ -62,7 +62,7 @@ const CookieBanner = ({ onCookieConsents }) => {
 
 CookieBanner.propTypes = {
     className: PropTypes.string,
-    onCookieConsents: PropTypes.func.isRequired,
+    onCookiesConsent: PropTypes.func.isRequired,
 };
 
 export default CookieBanner;

--- a/www/shared/modules/react-cookie-banner/CookieBanner.test.js
+++ b/www/shared/modules/react-cookie-banner/CookieBanner.test.js
@@ -10,95 +10,95 @@ it('should not render banner when banner was previously dismissed', () => {
     jest.spyOn(document, 'cookie', 'get').mockImplementation(() => 'cookieBannerDismissed=true');
 
     const { container } = render(
-        <CookieBanner onCookieConsents={ () => {} } />,
+        <CookieBanner onCookiesConsent={ () => {} } />,
     );
 
     expect(container.innerHTML).toBe('');
 });
 
 it('should not render banner if there\'s at least one consent', () => {
-    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => 'cookieConsents=%5B%22analytics%22%5D');
+    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => 'cookiesConsent=%5B%22analytics%22%5D');
 
     const { container } = render(
-        <CookieBanner onCookieConsents={ () => {} } />,
+        <CookieBanner onCookiesConsent={ () => {} } />,
     );
 
     expect(container.innerHTML).toBe('');
 });
 
 it('should render if not dismissed and no consent was given', () => {
-    render(<CookieBanner onCookieConsents={ () => {} } />);
+    render(<CookieBanner onCookiesConsent={ () => {} } />);
 
     expect(screen.getByText('cookie-banner.text')).toBeInTheDocument();
 });
 
-it('should call onCookieConsents with the correct consents on mount', () => {
-    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => 'cookieConsents=%5B%22analytics%22%5D');
+it('should call onCookiesConsent with the correct consents on mount', () => {
+    jest.spyOn(document, 'cookie', 'get').mockImplementation(() => 'cookiesConsent=%5B%22analytics%22%5D');
 
-    const handleCookieConsents = jest.fn();
+    const handleCookiesConsent = jest.fn();
 
     const { unmount } = render(
-        <CookieBanner onCookieConsents={ handleCookieConsents } />,
+        <CookieBanner onCookiesConsent={ handleCookiesConsent } />,
     );
 
-    expect(handleCookieConsents).toHaveBeenCalledTimes(1);
-    expect(handleCookieConsents).toHaveBeenCalledWith(['analytics']);
+    expect(handleCookiesConsent).toHaveBeenCalledTimes(1);
+    expect(handleCookiesConsent).toHaveBeenCalledWith(['analytics']);
 
-    handleCookieConsents.mockReset();
+    handleCookiesConsent.mockReset();
     jest.spyOn(document, 'cookie', 'get').mockImplementation(() => '');
 
     unmount();
     render(
-        <CookieBanner onCookieConsents={ handleCookieConsents } />,
+        <CookieBanner onCookiesConsent={ handleCookiesConsent } />,
     );
 
-    expect(handleCookieConsents).toHaveBeenCalledTimes(1);
-    expect(handleCookieConsents).toHaveBeenCalledWith([]);
+    expect(handleCookiesConsent).toHaveBeenCalledTimes(1);
+    expect(handleCookiesConsent).toHaveBeenCalledWith([]);
 });
 
 it('should behave well when the accept button is clicked', () => {
-    const handleCookieConsents = jest.fn();
+    const handleCookiesConsent = jest.fn();
 
     const { container, rerender, getByText } = render(
-        <CookieBanner onCookieConsents={ handleCookieConsents } />,
+        <CookieBanner onCookiesConsent={ handleCookiesConsent } />,
     );
 
-    handleCookieConsents.mockClear();
+    handleCookiesConsent.mockClear();
 
     userEvent.click(getByText('cookie-banner.accept'));
 
-    expect(handleCookieConsents).toHaveBeenCalledTimes(1);
-    expect(handleCookieConsents).toHaveBeenCalledWith(['analytics']);
+    expect(handleCookiesConsent).toHaveBeenCalledTimes(1);
+    expect(handleCookiesConsent).toHaveBeenCalledWith(['analytics']);
 
-    handleCookieConsents.mockClear();
+    handleCookiesConsent.mockClear();
 
     rerender(
-        <CookieBanner onCookieConsents={ handleCookieConsents } />,
+        <CookieBanner onCookiesConsent={ handleCookiesConsent } />,
     );
 
-    expect(handleCookieConsents).not.toHaveBeenCalled();
+    expect(handleCookiesConsent).not.toHaveBeenCalled();
     expect(container.innerHTML).toBe('');
 });
 
 it('should behave well when the reject button is clicked', () => {
-    const handleCookieConsents = jest.fn();
+    const handleCookiesConsent = jest.fn();
 
     const { container, rerender } = render(
-        <CookieBanner onCookieConsents={ handleCookieConsents } />,
+        <CookieBanner onCookiesConsent={ handleCookiesConsent } />,
     );
 
     expect(container.innerHTML).not.toBe('');
 
-    handleCookieConsents.mockClear();
+    handleCookiesConsent.mockClear();
 
     userEvent.click(screen.getByText('cookie-banner.reject'));
 
-    expect(handleCookieConsents).not.toHaveBeenCalled();
+    expect(handleCookiesConsent).not.toHaveBeenCalled();
 
     rerender(
-        <CookieBanner onCookieConsents={ handleCookieConsents } />,
+        <CookieBanner onCookiesConsent={ handleCookiesConsent } />,
     );
 
-    expect(handleCookieConsents).not.toHaveBeenCalled();
+    expect(handleCookiesConsent).not.toHaveBeenCalled();
     expect(container.innerHTML).toBe('');
 });


### PR DESCRIPTION
Changes all instances of `cookieConsents` and `CookieConsents` to `cookiesConsent` and `CookiesConsent`, respectively, where the change in wording is meant to express "The user provides **consent** for **cookies**".

This is because consent is an uncountable noun in this context. `Consents` is a valid word, but only when the consent in question relates to e.g. documents or otherwise numerable items that individually express some consent, which is not the case here.