### PR TITLE
Use new syntax to set environment variables in CI

### DIFF
--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -27,14 +27,14 @@ jobs:
         env:
           SITE_URL: https://next-with-moxy.vercel.app
         run: |
-          echo "::set-env name=SITE_URL::$SITE_URL"
+          echo "SITE_URL=$SITE_URL" >> $GITHUB_ENV
 
       - name: Set environment variables (PR)
         if: github.event_name == 'pull_request'
         env:
           SITE_URL: https://next-with-moxy-pr-${{ github.event.number }}.vercel.app
         run: |
-          echo "::set-env name=SITE_URL::$SITE_URL"
+          echo "SITE_URL=$SITE_URL" >> $GITHUB_ENV
 
       - name: Comment URL
         if: github.event_name == 'pull_request' && github.event.action == 'opened'

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -75,11 +75,12 @@ jobs:
               --build-env SITE_URL=$SITE_URL \
           )
 
+          DEPLOYMENT_URL_ALIAS=$(echo $SITE_URL | sed 's/https\?:\/\///')
           npx vercel alias \
             -t $VERCEL_TOKEN \
             --scope moxystudio \
             $DEPLOYMENT_URL \
-            $SITE_URL
+            $DEPLOYMENT_URL_ALIAS
 
       - name: Set success deployment status
         if: success()


### PR DESCRIPTION
The workflow which deploys to Vercel is currently failing:

![Screenshot 2021-01-14 at 13 09 08](https://user-images.githubusercontent.com/2727522/104595078-fbbdb200-5669-11eb-9320-004f6c32d988.png)

The `set-env` command was [deprecated](https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/) a few months ago and recently disabled. This PR updates the workflow to use the [new syntax](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files).